### PR TITLE
Feat wishlist page

### DIFF
--- a/pages/wishlist.js
+++ b/pages/wishlist.js
@@ -1,14 +1,13 @@
 import Link from "next/link";
 import Head from "next/head";
-import NavBar from "../components/NavBar";
 import Layout from "../components/Layout";
 import { useSelector } from "react-redux";
 import { selectWishlist } from "../redux/count/selector";
 import { selectUser } from "../redux/user/selector";
-import WishlistItems from "../components/WishlistItem";
 import HeaderImage from "../components/HeaderImage";
 import utilStyles from "../styles/utils.module.css";
 import SharingButtons from "../components/SharingButtons";
+import AddCount from "../components/AddCount";
 
 export default function Wishlist({ indoorskiplaces }) {
   const wishlistItems = useSelector(selectWishlist);
@@ -26,9 +25,6 @@ export default function Wishlist({ indoorskiplaces }) {
     return itemsOnTheList;
   });
 
-  // To do: display the filtered list instead of the wishlistitems
-  // console.log("Did we get the filtered list?", list);
-
   return (
     <>
       <Head>
@@ -44,7 +40,32 @@ export default function Wishlist({ indoorskiplaces }) {
           <h2>Check out your wishlist {user.name}!</h2>
           <ul>
             {wishlistItems.map((wishlistItem, key) => {
-              return <li key={wishlistItem}>{wishlistItem}</li>;
+              const itemOnTheList = list.find(function (item) {
+                return item.id === wishlistItem;
+              });
+
+              const info = () => {
+                if (itemOnTheList == undefined) {
+                  return "";
+                } else {
+                  return (
+                    <>
+                      <img
+                        src={itemOnTheList.imageUrl}
+                        style={{ maxWidth: "200px", maxHeight: "200px" }}
+                      />
+                      <p>{itemOnTheList.name}</p>
+                      <div>
+                        <AddCount id={itemOnTheList.id} />
+                      </div>
+                    </>
+                  );
+                }
+              };
+
+              const showInfo = info();
+
+              return <li key={wishlistItem}>{showInfo}</li>;
             })}
           </ul>
           <SharingButtons />

--- a/redux/count/selector.js
+++ b/redux/count/selector.js
@@ -1,3 +1,9 @@
-export const selectWishlistCount = (state) => state.count.wishlist.length;
+export const selectWishlistCount = (state) => {
+  if (state.count.wishlist[0] === null) {
+    return state.count.wishlist.length - 1;
+  } else {
+    return state.count.wishlist.length;
+  }
+};
 
 export const selectWishlist = (state) => state.count.wishlist;


### PR DESCRIPTION
## In this pull request:

- Instead of the number of items that were displayed on the wishlistpage, the actual name and image is displayed as well as the heart button
- A bug was fixed with the persist/hydrate state were it would count the zero index of the wishlist as null or other times as ""
